### PR TITLE
Käytetään google-chrome-stablea joka sisältää libxss1:n

### DIFF
--- a/provision/800-digabi.sh
+++ b/provision/800-digabi.sh
@@ -76,7 +76,7 @@ EOF
 
 apt-get update
 
-apt-get -y -o "Acquire::http::Pipeline-Depth=10" install ruby-dev zip nginx libpq-dev google-chrome-unstable libnss3-tools git rsync curl unzip ruby parallel uuid-runtime netcat-traditional locales postgresql-9.6 postgresql-contrib-9.6 texlive-base texlive-latex-base texlive-lang-european texlive-fonts-recommended texlive-fonts-extra texlive-latex-recommended texlive-latex-extra latexmk net-tools icu-devtools libgconf-2-4 tmux jq
+apt-get -y -o "Acquire::http::Pipeline-Depth=10" install ruby-dev zip nginx libpq-dev google-chrome-stable libnss3-tools git rsync curl unzip ruby parallel uuid-runtime netcat-traditional locales postgresql-9.6 postgresql-contrib-9.6 texlive-base texlive-latex-base texlive-lang-european texlive-fonts-recommended texlive-fonts-extra texlive-latex-recommended texlive-latex-extra latexmk net-tools icu-devtools libgconf-2-4 tmux jq
 curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | sudo -u vagrant bash
 sudo -u vagrant /bin/bash -c ". ~/.nvm/nvm.sh; for v in 8.11.3 10.17.0 12.4.0 12.6.0 12.7.0 12.8.0 12.14.0; do nvm install \$v; nvm exec \$v npm install -g yarn; done; nvm alias default 8"
 


### PR DESCRIPTION
google-chrome-unstable doesn't install libxss1 any more that is needed by puppeteer

Switch to google-chrome-stable that has it still